### PR TITLE
feat(magi): Add logger module and fix .gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ log*
 /tmp/
 .venv/
 .qoder/
+
+!logger.py

--- a/inferix/models/magi/logger.py
+++ b/inferix/models/magi/logger.py
@@ -1,0 +1,20 @@
+import logging
+
+def get_logger(name: str = "magi") -> logging.Logger:
+    """Get a logger for MAGI model operations."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        # Add console handler if no handlers exist
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            fmt='[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S'
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+    return logger
+
+# Create the default magi_logger instance
+magi_logger = get_logger()


### PR DESCRIPTION
1. Add `inferix/models/magi/logger.py` to implement the `magi_logger` logging utility, resolving the import error `from inferix.models.magi.logger import magi_logger` reported in issue #5
2. Optimize .gitignore rules by refining `log*` patterns to avoid matching source files like `logger.py`
